### PR TITLE
Add .NOTPARALLEL to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VERSION = 0.4.0
 PKGFILE = $(NAME).kwinscript
 PKGDIR = pkg
 
-.NOTPARALLEL:
+.NOTPARALLEL: all
 
 all: build install clean
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ VERSION = 0.4.0
 PKGFILE = $(NAME).kwinscript
 PKGDIR = pkg
 
+.NOTPARALLEL:
+
 all: build install clean
 
 build: res src


### PR DESCRIPTION
Disable parallel processing of makefile targets for users who have set custom makeflags or try to run make with a -j larger than 1