### PR TITLE
Create actual nightly release when pushing to master

### DIFF
--- a/.github/workflows/build_kwinscript.yml
+++ b/.github/workflows/build_kwinscript.yml
@@ -1,8 +1,6 @@
 name: Make polonium.kwinscript
 
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/publish_kwinscript.yml
+++ b/.github/workflows/publish_kwinscript.yml
@@ -1,0 +1,33 @@
+name: Publish polonium.kwinscript
+
+on:
+  push:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: sudo apt-get install -y kpackagetool5 npm node-typescript
+
+    - name: Build with make
+      run: |
+        make build
+        sha256sum polonium.kwinscript > polonium.kwinscript.sha256sum
+
+    - name: Create release
+      run: |
+        gh release delete nightly --yes || true
+        gh release create nightly \
+          --prerelease \
+          --title "Development build" \
+          --notes "Get the latest version with all the new bugs and features." \
+          polonium.kwinscript*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.kwinscript*
 pkg/
 *.kate-swp
 src/**/*.js

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,7 +3,7 @@
 ## Installation
 
 Do one of the following -
-* Go to [GitHub Actions](https://github.com/zeroxoneafour/polonium/actions/workflows/kwinscript.yml) and download the artifact from the latest build, then install it in KWin Scripts in the settings menu. This will give you the master build of Polonium
+* Go to [GitHub](https://github.com/zeroxoneafour/polonium/releases/) and download the `polonium.kwinscript` asset from a release of your choice, then install it in KWin Scripts in the settings menu
 * Go to the [KWin Store](https://store.kde.org/p/2042756) and download the latest `polonium.kwinscript`, then install it in KWin Scripts
 * Go to KWin Scripts settings panel and Get New Scripts, then search for and select Polonium
 


### PR DESCRIPTION
The artifacts from Github Actions are only kept for a limited time.
You need to be logged into Github to download any artifacts.
You need to know how that page even works in the first place to find anything.

This creates an actual release when changes are pushed/merged to `master`. It still only builds and uploads artifacts for pull requests.
Looks like this: https://github.com/Daxtorim/polonium/releases