### PR TITLE
fix: delete nightly tag before creating new release

### DIFF
--- a/.github/workflows/publish_kwinscript.yml
+++ b/.github/workflows/publish_kwinscript.yml
@@ -26,6 +26,7 @@ jobs:
     - name: Create release
       run: |
         gh release delete nightly --yes || true
+        git push --delete origin refs/tags/nightly || true
         gh release create nightly \
           --prerelease \
           --title "Development build" \


### PR DESCRIPTION
My bad here, I thought deleting the release would be enough but apparently it leaves the tag intact. The nightly tag is still pointing to the merge commit of the original PR.
It's a cosmetic change mostly, the kwinscript attached to the release is the correct one, just the tag is pointing to the wrong commit and the attached source code (`nightly.zip`/`nightly.tar.gz`) is the wrong version.

So this will update the tag now as well...by deleting it...and then creating it again.