### PR TITLE
chore: format

### DIFF
--- a/src/controller/actions/windowhooks.ts
+++ b/src/controller/actions/windowhooks.ts
@@ -66,17 +66,11 @@ export class WindowHooks {
     // have to use imrs and tilechanged
     // interactive mr handles moving out of tiles, tilechanged handles moving into tiles
     tileChanged(tile: Tile) {
-        if (
-            this.ctrl.driverManager.buildingLayout ||
-            tile == null
-        ) {
+        if (this.ctrl.driverManager.buildingLayout || tile == null) {
             return;
         }
         // client is moved into managed tile from outside
-        if (
-            !this.extensions.isTiled &&
-            this.ctrl.managedTiles.has(tile)
-        ) {
+        if (!this.extensions.isTiled && this.ctrl.managedTiles.has(tile)) {
             this.logger.debug(
                 "Putting window",
                 this.window.resourceClass,
@@ -95,7 +89,11 @@ export class WindowHooks {
         }
         // client is in a non-managed tile (move it to a managed one)
         else if (!this.ctrl.managedTiles.has(tile)) {
-            this.logger.debug("Window", this.window.resourceClass, "moved into an unmanaged tile");
+            this.logger.debug(
+                "Window",
+                this.window.resourceClass,
+                "moved into an unmanaged tile",
+            );
             const center = new GRect(tile.absoluteGeometryInScreen).center;
             let newTile = this.ctrl.workspace
                 .tilingForScreen(this.window.output)
@@ -114,12 +112,14 @@ export class WindowHooks {
             this.ctrl.driverManager.putWindowInTile(
                 this.window,
                 newTile,
-                new GRect(newTile.absoluteGeometryInScreen).directionFromPoint(center),
+                new GRect(newTile.absoluteGeometryInScreen).directionFromPoint(
+                    center,
+                ),
             );
             this.ctrl.driverManager.rebuildLayout(this.window.output);
         }
     }
-    
+
     // should be fine if i just leave this here without a timer
     interactiveMoveResizeStepped() {
         if (
@@ -158,7 +158,7 @@ export class WindowHooks {
             this.ctrl.driverManager.rebuildLayout(this.window.output);
         }
     }
-    
+
     putWindowInBestTile(): void {
         if (this.extensions.lastTiledLocation != null) {
             // fancy and illegally long code to place tile in a similar position from when it was untiled
@@ -252,9 +252,7 @@ export class WindowHooks {
             "set to",
             maximized,
         );
-        if (
-            (maximized && this.extensions.isTiled)
-        ) {
+        if (maximized && this.extensions.isTiled) {
             this.ctrl.driverManager.untileWindow(this.window);
             this.ctrl.driverManager.rebuildLayout(this.window.output);
             this.extensions.wasTiled = true;

--- a/src/driver/driver.ts
+++ b/src/driver/driver.ts
@@ -202,14 +202,17 @@ export class TilingDriver {
             this.fixSizing(tile, kwinTile);
         }
     }
-    
+
     fixSizing(tile: Tile, kwinTile: Kwin.Tile): void {
         // only resize if not root tile (obv)
         if (tile.parent == null || kwinTile.parent == null) {
             return;
         }
         let index = tile.parent.tiles.indexOf(tile);
-        let parentIndex = tile.parent.parent != null ? tile.parent.parent.tiles.indexOf(tile.parent) : null;
+        let parentIndex =
+            tile.parent.parent != null
+                ? tile.parent.parent.tiles.indexOf(tile.parent)
+                : null;
         const requestedSize = new GSize();
         requestedSize.fitSize(tile.requestedSize);
         for (const client of tile.clients) {
@@ -219,12 +222,12 @@ export class TilingDriver {
             }
             requestedSize.fitSize(window.minSize);
         }
-        const horizontal = kwinTile.parent.layoutDirection == Kwin.LayoutDirection.Horizontal;
+        const horizontal =
+            kwinTile.parent.layoutDirection == Kwin.LayoutDirection.Horizontal;
         // horiz resize
         if (requestedSize.width > kwinTile.absoluteGeometryInScreen.width) {
             let diff =
-                requestedSize.width -
-                kwinTile.absoluteGeometryInScreen.width;
+                requestedSize.width - kwinTile.absoluteGeometryInScreen.width;
             if (horizontal) {
                 // if the layout is horizontal already, width resizing should be easy
                 if (index == 0) {
@@ -249,18 +252,14 @@ export class TilingDriver {
         // vertical resize
         if (requestedSize.height > kwinTile.absoluteGeometryInScreen.height) {
             let diff =
-                requestedSize.height -
-                kwinTile.absoluteGeometryInScreen.height;
+                requestedSize.height - kwinTile.absoluteGeometryInScreen.height;
             if (!horizontal) {
                 if (index == 0) {
                     // first tile in sequence, shift border down
                     kwinTile.resizeByPixels(diff, Kwin.Edge.BottomEdge);
                 } else {
                     // shift border up
-                    kwinTile.resizeByPixels(
-                        -diff,
-                        Kwin.Edge.TopEdge,
-                    );
+                    kwinTile.resizeByPixels(-diff, Kwin.Edge.TopEdge);
                 }
             } else if (parentIndex != null) {
                 if (parentIndex == 0) {

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -21,12 +21,12 @@ export class DriverManager {
 
     buildingLayout: boolean = false;
     resizingLayout: boolean = false;
-    
+
     constructor(c: Controller) {
         this.ctrl = c;
         this.engineFactory = new TilingEngineFactory(this.ctrl.config);
         this.logger = c.logger;
-        this.config = c.config;        
+        this.config = c.config;
     }
 
     init(): void {

--- a/src/util/geometry.ts
+++ b/src/util/geometry.ts
@@ -90,7 +90,7 @@ export class GPoint implements QPoint {
             y: r.y + r.height / 2,
         });
     }
-    
+
     toString(): string {
         return "GPoint(" + this.x + ", " + this.y + ")";
     }
@@ -192,7 +192,17 @@ export class GRect implements QRect {
     }
 
     toString(): string {
-        return "GRect(" + this.x + ", " + this.y + + ", " + this.width + ", " + this.height + ")";
+        return (
+            "GRect(" +
+            this.x +
+            ", " +
+            this.y +
+            +", " +
+            this.width +
+            ", " +
+            this.height +
+            ")"
+        );
     }
 }
 


### PR DESCRIPTION
Formats the non-conforming files with the projects prettier config.

For developer and accessibility friendliness I'd recommend updating the config to use tabs for indention, preserving spaces for alignment. With tabs one indentation is always one indention and it's width can be individually set to the needs of a developer.