### PR TITLE
ci: add lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint
+
+on:
+    push:
+    pull_request:
+
+jobs:
+    formatting:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Verify formatting
+              uses: creyD/prettier_action@v4.3
+              with:
+                  prettier_options: --check .


### PR DESCRIPTION
Adds a first workflow configuration for linting. 

Will be green after #160 

Sample run on fork: https://github.com/ttytm/polonium/actions/runs/8853446047