### PR TITLE
Toggle rotateLayout automatically to support vertical outputs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -82,6 +82,7 @@ Polonium requires that KWin be restarted every time the configuration is changed
 - Layout engine (dropdown) - The default tiling engine you want to use on new desktops
 - Insertion point (dropdown) - Select where new windows should be inserted into the layout
 - Rotate layout (check box) - Whether to rotate the layout 90 degrees (split horizontally instead of vertically)
+- Auto rotate layout (check box) - Automatically rotate layout if desktop/output width is less than its height (for example in case of vertical display)
 
 ### Debug options
 

--- a/res/config.ui
+++ b/res/config.ui
@@ -120,6 +120,16 @@
      </property>
     </widget>
    </item>
+   <item row="39" column="1">
+    <widget class="QCheckBox" name="kcfg_AutoRotateLayout">
+     <property name="text">
+      <string>Auto rotate layout</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
    <item row="13" column="1">
     <widget class="QCheckBox" name="kcfg_KeepTiledBelow">
      <property name="text">

--- a/res/main.xml
+++ b/res/main.xml
@@ -15,5 +15,6 @@
         <entry name="EngineType" type="int"><default>0</default></entry>
         <entry name="InsertionPoint" type="int"><default>0</default></entry>
         <entry name="RotateLayout" type="bool"><default>false</default></entry>
+        <entry name="AutoRotateLayout" type="bool"><default>true</default></entry>
     </group>
 </kcfg>

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -57,7 +57,7 @@ export class DriverManager {
                 let rotate = this.config.rotateLayout;
                 if (desktop.output.geometry.width < desktop.output.geometry.height)
                 {
-                    this.logger.debug("Rotate layout for desktop", desktopString)
+                    this.logger.debug("Rotate layout for desktop", desktopString);
                     rotate = !rotate;
                 }
                 const config: EngineConfig = {

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -54,10 +54,16 @@ export class DriverManager {
                     desktopString,
                 );
                 let engineType = this.config.engineType;
+                let rotate = this.config.rotateLayout;
+                if (desktop.output.geometry.width < desktop.output.geometry.height)
+                {
+                    this.logger.debug("Rotate layout for desktop", desktopString)
+                    rotate = !rotate;
+                }
                 const config: EngineConfig = {
                     engineType: engineType,
                     insertionPoint: this.config.insertionPoint,
-                    rotateLayout: this.config.rotateLayout,
+                    rotateLayout: rotate,
                     engineSettings: {},
                 };
                 const engine = this.engineFactory.newEngine(config);

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -55,9 +55,9 @@ export class DriverManager {
                 );
                 let engineType = this.config.engineType;
                 let rotate = this.config.rotateLayout;
-                if (desktop.output.geometry.width < desktop.output.geometry.height)
-                {
-                    this.logger.debug("Rotate layout for desktop", desktopString);
+                if (this.config.autoRotateLayout &&
+                    desktop.output.geometry.width < desktop.output.geometry.height) {
+                    this.logger.debug("Auto rotate layout for desktop", desktopString);
                     rotate = !rotate;
                 }
                 const config: EngineConfig = {

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -54,16 +54,16 @@ export class DriverManager {
                     desktopString,
                 );
                 let engineType = this.config.engineType;
-                let rotate = this.config.rotateLayout;
+                let rotateLayout = this.config.rotateLayout;
                 if (this.config.autoRotateLayout &&
                     desktop.output.geometry.width < desktop.output.geometry.height) {
                     this.logger.debug("Auto rotate layout for desktop", desktopString);
-                    rotate = !rotate;
+                    rotateLayout = !rotateLayout;
                 }
                 const config: EngineConfig = {
                     engineType: engineType,
                     insertionPoint: this.config.insertionPoint,
-                    rotateLayout: rotate,
+                    rotateLayout: rotateLayout,
                     engineSettings: {},
                 };
                 const engine = this.engineFactory.newEngine(config);

--- a/src/qml/settings.qml
+++ b/src/qml/settings.qml
@@ -13,7 +13,6 @@ PlasmaCore.Dialog {
         // 0 - left side, 1 - right side, 2 - active
         insertionPoint: 1,
         rotateLayout: false,
-        autoRotateLayout: true,
     })
     
     property var desktop: ({
@@ -35,7 +34,6 @@ PlasmaCore.Dialog {
         this.settings.engineType = s.engineType;
         this.settings.insertionPoint = s.insertionPoint;
         this.settings.rotateLayout = s.rotateLayout;
-        this.settings.autoRotateLayout = s.autoRotateLayout;
     }
     
     function show() {
@@ -48,7 +46,6 @@ PlasmaCore.Dialog {
         engine.currentIndex = this.settings.engineType;
         insertionPoint.currentIndex = this.settings.insertionPoint;
         rotateLayout.checkState = this.settings.rotateLayout ? Qt.Checked : Qt.Unchecked;
-        autoRotateLayout.checkState = this.settings.autoRotateLayout ? Qt.Checked : Qt.Unchecked;
         
         // Update current screen information
         this.screenGeometry = Workspace.clientArea(KWin.FullScreenArea, Workspace.activeScreen, Workspace.currentDesktop);
@@ -68,7 +65,6 @@ PlasmaCore.Dialog {
         this.settings.engineType = engine.currentIndex;
         this.settings.insertionPoint = insertionPoint.currentIndex;
         this.settings.rotateLayout = (rotateLayout.checkState == Qt.Checked);
-        this.settings.autoRotateLayout = (autoRotateLayout.checkState == Qt.Checked);
         this.saveSettingsInternal(this.settings, this.desktop);
     }
     
@@ -117,11 +113,6 @@ PlasmaCore.Dialog {
             PC3.CheckBox {
                 id: rotateLayout;
                 text: "Rotate Layout"
-            }
-            
-            PC3.CheckBox {
-                id: autoRotateLayout;
-                text: "Auto Rotate Layout"
             }
         }
         

--- a/src/qml/settings.qml
+++ b/src/qml/settings.qml
@@ -13,6 +13,7 @@ PlasmaCore.Dialog {
         // 0 - left side, 1 - right side, 2 - active
         insertionPoint: 1,
         rotateLayout: false,
+        autoRotateLayout: true,
     })
     
     property var desktop: ({
@@ -34,6 +35,7 @@ PlasmaCore.Dialog {
         this.settings.engineType = s.engineType;
         this.settings.insertionPoint = s.insertionPoint;
         this.settings.rotateLayout = s.rotateLayout;
+        this.settings.autoRotateLayout = s.autoRotateLayout;
     }
     
     function show() {
@@ -46,6 +48,7 @@ PlasmaCore.Dialog {
         engine.currentIndex = this.settings.engineType;
         insertionPoint.currentIndex = this.settings.insertionPoint;
         rotateLayout.checkState = this.settings.rotateLayout ? Qt.Checked : Qt.Unchecked;
+        autoRotateLayout.checkState = this.settings.autoRotateLayout ? Qt.Checked : Qt.Unchecked;
         
         // Update current screen information
         this.screenGeometry = Workspace.clientArea(KWin.FullScreenArea, Workspace.activeScreen, Workspace.currentDesktop);
@@ -65,6 +68,7 @@ PlasmaCore.Dialog {
         this.settings.engineType = engine.currentIndex;
         this.settings.insertionPoint = insertionPoint.currentIndex;
         this.settings.rotateLayout = (rotateLayout.checkState == Qt.Checked);
+        this.settings.autoRotateLayout = (autoRotateLayout.checkState == Qt.Checked);
         this.saveSettingsInternal(this.settings, this.desktop);
     }
     
@@ -113,6 +117,11 @@ PlasmaCore.Dialog {
             PC3.CheckBox {
                 id: rotateLayout;
                 text: "Rotate Layout"
+            }
+            
+            PC3.CheckBox {
+                id: autoRotateLayout;
+                text: "Auto Rotate Layout"
             }
         }
         

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -51,6 +51,7 @@ export class Config {
         this.engineType = rc("EngineType", EngineType.BTree);
         this.insertionPoint = rc("InsertionPoint", InsertionPoint.Left);
         this.rotateLayout = rc("RotateLayout", false);
+        this.autoRotateLayout = rc("AutoRotateLayout", true);
     }
 
     debug: boolean = false;
@@ -75,4 +76,5 @@ export class Config {
     engineType: EngineType = EngineType.BTree;
     insertionPoint: InsertionPoint = InsertionPoint.Left;
     rotateLayout: boolean = true;
+    autoRotateLayout: boolean = true;
 }


### PR DESCRIPTION
Automatically toggle "Rotate layout" if desktop/output width is less than its height. This makes layout engines to split along the major output axis first. For example, vertical outputs will first split vertically when using btree engine.

The change honors the "Rotate layout" setting in the UI by toggling its value instead of overriding it.

A new UI setting "Auto rotate layout" has been added and enabled by default.