### PR TITLE
Add window based on current pos

### DIFF
--- a/src/controller/actions/shortcuts.ts
+++ b/src/controller/actions/shortcuts.ts
@@ -193,9 +193,11 @@ export class ShortcutManager {
             return;
         }
         if (this.ctrl.windowExtensions.get(window)!.isTiled) {
+            this.ctrl.windowExtensions.get(window)!.shouldTile = false;
             this.ctrl.driverManager.untileWindow(window);
         } else {
-            this.ctrl.driverManager.addWindow(window);
+            this.ctrl.windowExtensions.get(window)!.shouldTile = true;
+            this.ctrl.driverManager.addWindowToPosition(window, null);
         }
         this.ctrl.driverManager.rebuildLayout();
     }

--- a/src/controller/extensions.ts
+++ b/src/controller/extensions.ts
@@ -56,6 +56,7 @@ export class WindowExtensions {
     private previousDesktopsInternal: Desktop[] = [];
     isTiled: boolean = false; // not is in a tile, but is registered in engine
     wasTiled: boolean = false; // windows that were tiled when they could be (minimized/maximized/fullscreen)
+    shouldTile: boolean = true;
     lastTiledLocation: GPoint | null = null;
     clientHooks: WindowHooks | null = null;
     isSingleMaximized: boolean = false; // whether the window is solo maximized or not (in accordance with maximize single windows)


### PR DESCRIPTION
Insert the windows based on their current location and force tile unless explicitly disabled with the shortcut.

You can drag and drop windows from one tile to another and it places them as expected (mostly, it is based on the middle of the window and not the cursor)

Related to issues #176 #158 #142 