### PR TITLE
Add restart engine shortcut

### DIFF
--- a/src/controller/actions/shortcuts.ts
+++ b/src/controller/actions/shortcuts.ts
@@ -356,5 +356,13 @@ export class ShortcutManager {
         engineConfig.engineType = engineType;
         this.ctrl.driverManager.setEngineConfig(desktop, engineConfig);
         this.ctrl.qmlObjects.osd.show("Restart: " + engineName(engineType));
+        this.ctrl.workspace.windows.forEach(window => {
+            if (this.ctrl.windowExtensions.get(window)!.isTiled) {
+                this.ctrl.driverManager.untileWindow(window);
+                this.ctrl.driverManager.rebuildLayout();
+                this.ctrl.driverManager.addWindowToPosition(window, null);
+                this.ctrl.driverManager.rebuildLayout();
+            }
+        });
     }
 }

--- a/src/controller/actions/shortcuts.ts
+++ b/src/controller/actions/shortcuts.ts
@@ -347,7 +347,14 @@ export class ShortcutManager {
         const desktop = this.ctrl.desktopFactory.createDefaultDesktop();
         const engineConfig = this.ctrl.driverManager.getEngineConfig(desktop);
         let engineType = engineConfig.engineType;
-        this.ctrl.qmlObjects.osd.show("Restart: " + engineName(engineType));
+        if (EngineType.BTree == engineType) {
+            engineConfig.engineType = EngineType.Half;
+        } else {
+            engineConfig.engineType = EngineType.BTree;
+        }
         this.ctrl.driverManager.setEngineConfig(desktop, engineConfig);
+        engineConfig.engineType = engineType;
+        this.ctrl.driverManager.setEngineConfig(desktop, engineConfig);
+        this.ctrl.qmlObjects.osd.show("Restart: " + engineName(engineType));
     }
 }

--- a/src/controller/actions/shortcuts.ts
+++ b/src/controller/actions/shortcuts.ts
@@ -163,6 +163,9 @@ export class ShortcutManager {
         shortcuts
             .getCycleEngine()
             .activated.connect(this.cycleEngine.bind(this));
+        shortcuts
+            .getRestartEngine()
+            .activated.connect(this.restartEngine.bind(this));
 
         shortcuts
             .getSwitchBTree()
@@ -337,6 +340,14 @@ export class ShortcutManager {
         engineType %= EngineType._loop;
         engineConfig.engineType = engineType;
         this.ctrl.qmlObjects.osd.show(engineName(engineType));
+        this.ctrl.driverManager.setEngineConfig(desktop, engineConfig);
+    }
+
+    restartEngine(): void {
+        const desktop = this.ctrl.desktopFactory.createDefaultDesktop();
+        const engineConfig = this.ctrl.driverManager.getEngineConfig(desktop);
+        let engineType = engineConfig.engineType;
+        this.ctrl.qmlObjects.osd.show("Restart: " + engineName(engineType));
         this.ctrl.driverManager.setEngineConfig(desktop, engineConfig);
     }
 }

--- a/src/controller/actions/shortcuts.ts
+++ b/src/controller/actions/shortcuts.ts
@@ -193,9 +193,11 @@ export class ShortcutManager {
             return;
         }
         if (this.ctrl.windowExtensions.get(window)!.isTiled) {
+            this.ctrl.windowExtensions.get(window)!.shouldTile = false;
             this.ctrl.driverManager.untileWindow(window);
         } else {
-            this.ctrl.driverManager.addWindow(window);
+            this.ctrl.windowExtensions.get(window)!.shouldTile = true;
+            this.ctrl.driverManager.addWindowToPosition(window, null);
         }
         this.ctrl.driverManager.rebuildLayout();
     }

--- a/src/controller/extensions.ts
+++ b/src/controller/extensions.ts
@@ -56,6 +56,7 @@ export class WindowExtensions {
     private previousDesktopsInternal: Desktop[] = [];
     isTiled: boolean = false; // not is in a tile, but is registered in engine
     wasTiled: boolean = false; // windows that were tiled when they could be (minimized/maximized/fullscreen)
+    shouldTile: boolean = true;
     lastTiledLocation: GPoint | null = null;
     clientHooks: WindowHooks | null = null;
     isSingleMaximized: boolean = false; // whether the window is solo maximized or not (in accordance with maximize single windows)

--- a/src/extern/qml.ts
+++ b/src/extern/qml.ts
@@ -57,6 +57,7 @@ export interface Shortcuts {
     getResizeRight(): ShortcutHandler;
 
     getCycleEngine(): ShortcutHandler;
+    getRestartEngine(): ShortcutHandler;
     getSwitchBTree(): ShortcutHandler;
     getSwitchHalf(): ShortcutHandler;
     getSwitchThreeColumn(): ShortcutHandler;

--- a/src/qml/shortcuts.qml
+++ b/src/qml/shortcuts.qml
@@ -160,6 +160,17 @@ Item {
         sequence: "Meta+Ctrl+L";
     }
     
+    function getRestartEngine() {
+        return restartEngine;
+    }
+    ShortcutHandler {
+        id: restartEngine;
+        
+        name: "PoloniumRestartEngine";
+        text: "Polonium: Restart Engine";
+        sequence: "Meta+Shift+R";
+    }
+    
     function getCycleEngine() {
         return cycleEngine;
     }


### PR DESCRIPTION
Sometimes (especially when performing operations fast) empty tiles appear. Restarting the engine solves that issue.