### PR TITLE
Add quit full screen for output

### DIFF
--- a/src/controller/actions/basic.ts
+++ b/src/controller/actions/basic.ts
@@ -71,6 +71,7 @@ export class WorkspaceActions {
         }
         this.logger.debug("Window", window.resourceClass, "added");
         this.ctrl.driverManager.addWindow(window);
+        this.ctrl.driverManager.quitFullScreen(window.output);
         this.ctrl.driverManager.rebuildLayout();
     }
 

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -340,4 +340,17 @@ export class DriverManager {
         this.ctrl.dbusManager.removeSettings(desktop.toString());
         this.rebuildLayout(desktop.output);
     }
+
+    quitFullScreen(output: Output): void {
+        this.ctrl.workspace.windows.forEach(window => {
+            if (window.output == output && window.fullScreen) {
+                window.fullScreen = false;
+            }
+            // not sure how to check for maximized so i just disable
+            // it for all in the same output.
+            if (window.output == output) {
+                window.setMaximize(false, false);
+            }
+        });
+    }
 }


### PR DESCRIPTION
When a new window appears, if there is a window in the same output that is maximied or fullscreen, unmaximize it/quit full screen