### PR TITLE
Launch polonium-saver through dbus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,13 @@ $(PKGDIR):
 	mkdir $(PKGDIR)/contents/config
 	mkdir $(PKGDIR)/contents/ui
 
+CARGO_HOME ?= $(HOME)/.cargo
+XDG_CONFIG_HOME ?= $(HOME)/.config
+XDG_DATA_HOME ?= $(HOME)/.local/share
+
 dbus:
 	cd dbus-saver && cargo install --path .
-	cp dbus-saver/polonium-saver.service ~/.config/systemd/user/
+	install -m 644 -D -t $(XDG_CONFIG_HOME)/systemd/user dbus-saver/polonium-saver.service
+	sed -i 's|^ExecStart=polonium-saver$$|ExecStart=$(CARGO_HOME)/bin/polonium-saver|' $(XDG_CONFIG_HOME)/systemd/user/polonium-saver.service
+	install -m 644 -D -t $(XDG_DATA_HOME)/dbus-1/services dbus-saver/xyz.vaughanm.polonium.service
+	sed -i 's|^Exec=polonium-saver$$|Exec=$(CARGO_HOME)/bin/polonium-saver|' $(XDG_DATA_HOME)/dbus-1/services/xyz.vaughanm.polonium.service

--- a/dbus-saver/polonium-saver.service
+++ b/dbus-saver/polonium-saver.service
@@ -1,10 +1,7 @@
 [Unit]
 Description=DBus saver for Polonium
-After=dbus.service
 
 [Service]
-Type=simple
-ExecStart=sh -c 'exec $HOME/.cargo/bin/polonium-saver'
-
-[Install]
-WantedBy=default.target
+Type=dbus
+ExecStart=polonium-saver
+BusName=xyz.vaughanm.polonium

--- a/dbus-saver/xyz.vaughanm.polonium.service
+++ b/dbus-saver/xyz.vaughanm.polonium.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=xyz.vaughanm.polonium
+Exec=polonium-saver
+SystemdService=polonium-saver.service


### PR DESCRIPTION
This delays launching `polonium-saver` until it is first called over dbus, so it doesn't run when not needed.