### PR TITLE
Add cycle through engines with a shortcut instead of using  dropdown menu 

### DIFF
--- a/src/controller/event.ts
+++ b/src/controller/event.ts
@@ -76,6 +76,7 @@ interface WindowActivatedEvent {
     output: Output;
 }
 
+
 export type Event =
     | TileWindowEvent
     | UntileWindowEvent
@@ -103,7 +104,14 @@ interface ToggleSettingsMenuEvent {
     output: Output;
 }
 
+
 export type PostEvent = SetWindowPropertiesEvent | ToggleSettingsMenuEvent;
+
+export interface GetCurrentEngineEvent {
+    desktop: VirtualDesktop;
+    activity: Activity;
+    output: Output;
+}
 
 // check if two events operate on the same window, desktops, and output
 function eventsAreParallel<

--- a/src/controller/event.ts
+++ b/src/controller/event.ts
@@ -76,7 +76,6 @@ interface WindowActivatedEvent {
     output: Output;
 }
 
-
 export type Event =
     | TileWindowEvent
     | UntileWindowEvent
@@ -104,14 +103,7 @@ interface ToggleSettingsMenuEvent {
     output: Output;
 }
 
-
 export type PostEvent = SetWindowPropertiesEvent | ToggleSettingsMenuEvent;
-
-export interface GetCurrentEngineEvent {
-    desktop: VirtualDesktop;
-    activity: Activity;
-    output: Output;
-}
 
 // check if two events operate on the same window, desktops, and output
 function eventsAreParallel<

--- a/src/controller/handlers/shortcuts.ts
+++ b/src/controller/handlers/shortcuts.ts
@@ -108,12 +108,11 @@ export class ShortcutsHandler {
         this.shortcuts
             .toggleSettingsMenu()
             .activated.connect(this.toggleSettingsMenu.bind(this));
-        
-        this.shortcuts
-            .getCycleEngine()
-            .activated.connect(this.cycleEngine.bind(this));
 
-  }
+        this.shortcuts
+            .cycleEngine()
+            .activated.connect(this.cycleEngine.bind(this));
+    }
 
     toggleActiveTiling() {
         const window = this.workspace.activeWindow;
@@ -230,7 +229,7 @@ export class ShortcutsHandler {
                 currentTile.absoluteGeometry.width / 2;
             const targetCenter =
                 targetTile.absoluteGeometry.x +
-              targetTile.absoluteGeometry.width / 2;
+                targetTile.absoluteGeometry.width / 2;
             if (currentCenter > targetCenter && direction !== undefined) {
                 direction |= Direction.Right;
             }
@@ -277,12 +276,17 @@ export class ShortcutsHandler {
     }
 
     cycleEngine() {
-    const current = ctrl().getCurrentEngineType({
-        desktop: this.workspace.currentDesktop,
-        activity: this.workspace.currentActivity,
-        output: this.workspace.activeScreen,
-    }) ?? TilingEngineType.BTree;
-    const next = (current + 1) % TilingEngineType._Loop;
-    this.setEngineType(next);
-}
+        const current = ctrl().getEngineType(
+            this.workspace.currentDesktop,
+            this.workspace.currentActivity,
+            this.workspace.activeScreen,
+        );
+        if (current === undefined) {
+            // Should never happen, but it's better for code quality
+            // that we assume that it can and we handle the error without assumption.
+            return;
+        }
+        const next = (current + 1) % TilingEngineType._Loop;
+        this.setEngineType(next);
+    }
 }

--- a/src/controller/handlers/shortcuts.ts
+++ b/src/controller/handlers/shortcuts.ts
@@ -108,7 +108,12 @@ export class ShortcutsHandler {
         this.shortcuts
             .toggleSettingsMenu()
             .activated.connect(this.toggleSettingsMenu.bind(this));
-    }
+        
+        this.shortcuts
+            .getCycleEngine()
+            .activated.connect(this.cycleEngine.bind(this));
+
+  }
 
     toggleActiveTiling() {
         const window = this.workspace.activeWindow;
@@ -225,7 +230,7 @@ export class ShortcutsHandler {
                 currentTile.absoluteGeometry.width / 2;
             const targetCenter =
                 targetTile.absoluteGeometry.x +
-                targetTile.absoluteGeometry.width / 2;
+              targetTile.absoluteGeometry.width / 2;
             if (currentCenter > targetCenter && direction !== undefined) {
                 direction |= Direction.Right;
             }
@@ -270,4 +275,14 @@ export class ShortcutsHandler {
             output: this.workspace.activeScreen,
         });
     }
+
+    cycleEngine() {
+    const current = ctrl().getCurrentEngineType({
+        desktop: this.workspace.currentDesktop,
+        activity: this.workspace.currentActivity,
+        output: this.workspace.activeScreen,
+    }) ?? TilingEngineType.BTree;
+    const next = (current + 1) % TilingEngineType._Loop;
+    this.setEngineType(next);
+}
 }

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -6,6 +6,8 @@ import {
     simplifyPostEvents,
     DesktopIdentifier,
     desktopId,
+    GetCurrentEngineEvent,
+    
 } from "./event";
 import { QmlApi, QmlObjects } from "../extern";
 import { Workspace } from "kwin-api/qml";
@@ -21,6 +23,7 @@ import { Console } from "./console";
 import { Driver } from "../driver";
 import { QTimer, Qt } from "kwin-api/qt";
 import { Config } from "./config";
+import { TilingEngineType } from "../engine";
 
 class Controller {
     private workspace: Workspace;
@@ -473,6 +476,10 @@ class Controller {
             this.workspace.windows.includes(window)
         );
     }
+  // avoid making driver instance public and get current tiling layout to enable cycling
+  getCurrentEngineType(type:GetCurrentEngineEvent): TilingEngineType | undefined {
+    return this.getDriver(type.desktop, type.activity, type.output)?.getEngineType();
+  }
 }
 
 let controllerObj: Controller;

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -6,8 +6,6 @@ import {
     simplifyPostEvents,
     DesktopIdentifier,
     desktopId,
-    GetCurrentEngineEvent,
-    
 } from "./event";
 import { QmlApi, QmlObjects } from "../extern";
 import { Workspace } from "kwin-api/qml";
@@ -476,10 +474,16 @@ class Controller {
             this.workspace.windows.includes(window)
         );
     }
-  // avoid making driver instance public and get current tiling layout to enable cycling
-  getCurrentEngineType(type:GetCurrentEngineEvent): TilingEngineType | undefined {
-    return this.getDriver(type.desktop, type.activity, type.output)?.getEngineType();
-  }
+    // avoid making driver instance public and get current tiling layout to enable cycling
+    getEngineType(
+        desktop: VirtualDesktop,
+        activity: Activity,
+        output: Output,
+    ): TilingEngineType | undefined {
+        return this.drivers
+            .get(desktopId(desktop, activity, output))
+            ?.getEngineType();
+    }
 }
 
 let controllerObj: Controller;

--- a/src/extern/index.ts
+++ b/src/extern/index.ts
@@ -45,7 +45,7 @@ export interface Shortcuts {
     resizeRight(): ShortcutHandler;
 
     toggleSettingsMenu(): ShortcutHandler;
-    getCycleEngine(): ShortcutHandler;
+    cycleEngine(): ShortcutHandler;
 }
 
 export interface Settings extends QObject {

--- a/src/extern/index.ts
+++ b/src/extern/index.ts
@@ -45,6 +45,7 @@ export interface Shortcuts {
     resizeRight(): ShortcutHandler;
 
     toggleSettingsMenu(): ShortcutHandler;
+    getCycleEngine(): ShortcutHandler;
 }
 
 export interface Settings extends QObject {

--- a/src/qml/shortcuts.qml
+++ b/src/qml/shortcuts.qml
@@ -220,19 +220,7 @@ Item {
         text: "Polonium: Toggle Settings Menu";
         sequence: "Meta+\\";
     }
-
-    /*
-    function getRotateLayout() {
-        return rotateLayout;
-    }
-    ShortcutHandler {
-        id: rotateLayout;
-
-        name: "PoloniumRotateLayout";
-        text: "Polonium: Rotate Layout";
-        sequence: "";
-    }
-    
+ 
     function getCycleEngine() {
         return cycleEngine;
     }
@@ -243,7 +231,19 @@ Item {
         text: "Polonium: Cycle Engine";
         sequence: "Meta+|";
     }
+    /*
+        function getRotateLayout() {
+        return rotateLayout;
+    }
+        ShortcutHandler {
+        id: rotateLayout;
+
+        name: "PoloniumRotateLayout";
+        text: "Polonium: Rotate Layout";
+        sequence: "";
+    }
     
+
     function getSwitchThreeColumn() {
         return switchThreeColumn;
     }
@@ -275,6 +275,6 @@ Item {
         name: "PoloniumSwitchKwin";
         text: "Polonium: Use KWin Engine";
         sequence: "";
-    }
-    */
+      }
+      */
 }

--- a/src/qml/shortcuts.qml
+++ b/src/qml/shortcuts.qml
@@ -221,11 +221,11 @@ Item {
         sequence: "Meta+\\";
     }
  
-    function getCycleEngine() {
-        return cycleEngine;
+    function cycleEngine() {
+        return cycleEngineObj;
     }
     ShortcutHandler {
-        id: cycleEngine;
+        id: cycleEngineObj;
         
         name: "PoloniumCycleEngine";
         text: "Polonium: Cycle Engine";


### PR DESCRIPTION
Been really enjoying  tiling with polonium. The only thing i was missing was an easy way to switch layouts without a menu. 
I saw the original  getCycleEngine() method commented out but couldn't find any actual implementation. I reenabled the shortcut and added a new controller to handle cycling  layouts.