### PR TITLE
Fix empty window filters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 - Reorganize settings
 - Add option for where to place dragged windows
 - Fix shift-dragging untiled windows
+- Fix empty window filters matching windows with empty classes or captions
 
 ### 1.2.1
 

--- a/src/controller/config.ts
+++ b/src/controller/config.ts
@@ -132,8 +132,11 @@ export class Config {
 }
 
 function commaRegex(str: string): string {
-    return str
+    const pattern = str
         .split(",")
         .map((x) => x.trim())
+        .filter(Boolean)
         .join("|");
+    // An empty pattern would become /^$/, matching windows with empty initial metadata.
+    return pattern || "(?!)";
 }


### PR DESCRIPTION
Prevent empty window filter lists from matching windows with empty initial classes or captions.

An empty filter previously became `/^$/`, which matches an empty string. This caused native Wayland applications such as PyCharm to be ignored before their window metadata was populated.

## Logs

Before the fix:

```text
Polonium WRN: Window pycharm not registered in windowMap
Polonium WRN: Window jetbrains-pycharm not registered in windowMap
```

After the fix, KWin reported an active tile:

```text
[AMP-PYCHARM-TILE-CHECK] jetbrains-pycharm true
```

## Verification

- `make lint`
- Tested with PyCharm 2026.2 on KDE Plasma 6.6.6 using native Wayland

I used a coding assistant to help identify the root cause and prepare the fix. I reviewed and tested the change manually.