### PR TITLE
Prevent layout rebuild loops

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 - Add option for where to place dragged windows
 - Fix shift-dragging untiled windows
 - Fix empty window filters matching windows with empty classes or captions
+- Prevent layout rebuild loops caused by internal tile changes
 
 ### 1.2.1
 

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -19,6 +19,7 @@ export class Driver {
     private windowMap: Map<KwinWindow, EngineWindow> = new Map();
     private untiledWindows: Set<KwinWindow> = new Set();
     private savedActiveWindow: KwinWindow | null = null;
+    private buildingLayout: boolean = false;
 
     private tilingEngine: TilingEngine;
 
@@ -108,7 +109,12 @@ export class Driver {
         }
 
         this.engineRootTile = this.tilingEngine.buildLayout();
-        this.tileMap = buildLayout(rootTile, this.engineRootTile);
+        this.buildingLayout = true;
+        try {
+            this.tileMap = buildLayout(rootTile, this.engineRootTile);
+        } finally {
+            this.buildingLayout = false;
+        }
         // clean out old hooked (callback set) tiles
         for (const hookedTile of this.hookedTiles) {
             if (!this.tileMap.has(hookedTile)) {
@@ -308,6 +314,9 @@ export class Driver {
     }
 
     private updateTileSizesCallback(display: Display) {
+        if (this.buildingLayout) {
+            return;
+        }
         ctrl().queueEvent({
             t: "updateTiles",
             display: display,
@@ -317,6 +326,9 @@ export class Driver {
     // when updating tile count we want to rebuild as for most engines this is an error
     // for kwin this is fine though
     private updateTileCountCallback(display: Display) {
+        if (this.buildingLayout) {
+            return;
+        }
         ctrl().queueEvent({
             t: "updateTiles",
             display: display,


### PR DESCRIPTION
## Summary

Ignore tile-change callbacks while Polonium is building a layout.

KWin emits `childTilesChanged` and `relativeGeometryChanged` during tile splits and geometry changes. Handling those signals as user edits can queue another rebuild and eventually freeze `kwin_wayland`.

Manual tile changes after the build are still handled normally.

## Testing

Tested on KWin 6.7.3 with 1–6 windows in ThreeColumn, Half, Pager, Pillars and BTree. Resizing, closing and reopening windows also worked.

`make lint` and `make build` pass.

Fixes #219
